### PR TITLE
Issues/001 url layout

### DIFF
--- a/2018/07/01/solid.html
+++ b/2018/07/01/solid.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0;url=/001-solid" />
+        <title>Page Moved</title>
+    </head>
+    <body>
+        This post has moved. Click <a href="/001-solid">here</a> to go to the new post.
+    </body>
+</html>

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ url: https://developermelange.github.io
 twitter_username: devmelange
 github_username:  developermelange
 
+permalink: /:title
 future: true
 
 hosts: 

--- a/_posts/2018-08-01-001-Solid.md
+++ b/_posts/2018-08-01-001-Solid.md
@@ -13,5 +13,4 @@ links:
   href: https://en.wikipedia.org/wiki/KISS_principle
 - title: Dan North - Why Every Element of SOLID is Wrong
   href: https://speakerdeck.com/tastapod/why-every-element-of-solid-is-wrong
-
 ---


### PR DESCRIPTION
* Changed Jekyll permalink to just `:title`. Extended title with episode number. Thus, `/2018/08/01/solid.html` has changed to `/001-solid`.
* Added simple meta-redirect for existing post. 

Fixes #1 