### PR TITLE
Revert use of developermelange.com as long as domain is broken

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-developermelange.com

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Home of Developer Melange / https://developermelange.com
+Home of Developer Melange / https://developermelange.github.io
 
 A podcast which brings you discussions about software engineering topics.
 All of them, in one way or another, related to building great software products.

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 title: Developer Melange
-email: delicious@developermelange.com
+email: developermelange@example.com
 description: >-
   A podcast which brings you discussions about software engineering topics.
   All of them, in one way or another, related to building great software products.
-url: https://developermelange.com
+url: https://developermelange.github.io
 twitter_username: devmelange
 github_username: developermelange
 

--- a/_posts/2020-06-01-033-testing-tour.md
+++ b/_posts/2020-06-01-033-testing-tour.md
@@ -21,7 +21,7 @@ links:
   - title: "Lisi's Testing Tour"
     href: https://www.lisihocke.com/2018/10/my-testing-tour-2018-a-challenge-worth-tackling.html
   - title: "Episode 18 - Who should do a journeyman tour?"
-    href: http://developermelange.com/018-why-journeyman-tour/
+    href: http://developermelange.github.io/018-why-journeyman-tour/
   - title: "SBA Live Academy"
     href: https://www.sba-research.org/sba-live-academy/
   - title: "Global Day of Mobretreat"


### PR DESCRIPTION
This PR drops the use of developermelange.com as its fix is uncertain.
As long as it is not available, at least the github pages should work. Core change is the removal of `CNAME` file.